### PR TITLE
change input order of kappa and beta

### DIFF
--- a/test/Homework/Week02Spec.hs
+++ b/test/Homework/Week02Spec.hs
@@ -85,7 +85,6 @@ spec = do
   describe "whatWentWrong" $ do
     it "will return the messages from LogMessages with Errors whose severity is 50+ - sorted by timestamp" $ do
       pending
-      let messages = [LogMessage (Error 49) 10 "alpha", LogMessage (Error 100) 9 "kappa", LogMessage (Error 51) 11 "beta", Unknown "foo", LogMessage Warning 100 "blar"]
+      let messages = [LogMessage (Error 49) 10 "alpha", LogMessage (Error 51) 11 "beta", LogMessage (Error 100) 9 "kappa", Unknown "foo", LogMessage Warning 100 "blar"]
 
       whatWentWrong messages `shouldBe` ["kappa", "beta"]
-


### PR DESCRIPTION
The final test in week 02 homework does not check that the result was sorted. The PDF says the input is an _unsorted_ list of log messages.  The test input is sorted so a solution will pass even if it does not sort the input.

This patch changes the order of kappa and beta in the input so sorting is required to pass the test.
