### PR TITLE
bump resolver to lts-5.3

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-3.16
+resolver: lts-5.3
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
- updates Aeson so it can parse plain strings, needed
  for Week07 tests
